### PR TITLE
Fix/missed min api version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 ### Deprecated
 - None
 
+## v0.3.6
+
+### Fixed
+- `Response` instance now includes required `min_api_version` in the root of request params taken from inputs.
+
 ## v0.3.5
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    viberroo (0.3.5)
+    viberroo (0.3.6)
       recursive-open-struct (~> 1.1.1)
 
 GEM

--- a/lib/viberroo/bot.rb
+++ b/lib/viberroo/bot.rb
@@ -140,8 +140,11 @@ module Viberroo
     # @see https://viber.github.io/docs/tools/keyboards/#buttons-parameters
     # @see https://developers.viber.com/docs/api/rest-bot-api/#keyboards
     #
-    def send_message(message, keyboard: {})
-      request(URL::MESSAGE, { receiver: @response.user_id }.merge(message, keyboard))
+    def send_message(message:, keyboard: {})
+      request(
+        URL::MESSAGE,
+        { receiver: @response.user_id }.merge(message, keyboard, min_api_version_hash(keyboard))
+      )
     end
 
     # @deprecated Use {#send_message} instead.
@@ -248,6 +251,25 @@ module Viberroo
     # @!visibility private
     def caller_name
       caller[1][/`.*'/][1..-2]
+    end
+
+    ##
+    # @!visibility private
+    #
+    # @note Iterates each keyboard input to identify the maximum required :min_api_version param.
+    #
+    # @return [Hash || Empty Hash]
+    #
+    def min_api_version_hash(keyboard)
+      buttons_array = keyboard.dig(:keyboard, :Buttons)
+
+      return {} unless buttons_array
+
+      min_api_version = buttons_array.map { |btn| btn[:min_api_version] }.compact.max
+
+      return {} unless min_api_version
+
+      { min_api_version: min_api_version }
     end
   end
 end

--- a/lib/viberroo/bot.rb
+++ b/lib/viberroo/bot.rb
@@ -151,7 +151,7 @@ module Viberroo
         minor release. Use Bot#send_message instead.
       WARNING
 
-      send_message(message, keyboard: keyboard)
+      send_message(message: message, keyboard: keyboard)
     end
 
     ##

--- a/lib/viberroo/bot.rb
+++ b/lib/viberroo/bot.rb
@@ -154,7 +154,7 @@ module Viberroo
         minor release. Use Bot#send_message instead.
       WARNING
 
-      send_message(message: message, keyboard: keyboard)
+      send_message(message, keyboard: keyboard)
     end
 
     ##

--- a/lib/viberroo/bot.rb
+++ b/lib/viberroo/bot.rb
@@ -140,10 +140,12 @@ module Viberroo
     # @see https://viber.github.io/docs/tools/keyboards/#buttons-parameters
     # @see https://developers.viber.com/docs/api/rest-bot-api/#keyboards
     #
-    def send_message(message:, keyboard: {})
+    def send_message(message, keyboard: {})
       request(
         URL::MESSAGE,
-        { receiver: @response.user_id }.merge(message, keyboard, min_api_version_hash(keyboard))
+        { receiver: @response.user_id }.merge(message, keyboard).tap do |hash|
+          hash.merge!(min_api_version_hash(keyboard)) unless hash[:min_api_version]
+        end
       )
     end
 

--- a/lib/viberroo/version.rb
+++ b/lib/viberroo/version.rb
@@ -1,3 +1,3 @@
 module Viberroo
-  VERSION = '0.3.5'.freeze
+  VERSION = '0.3.6'.freeze
 end

--- a/spec/bot_spec.rb
+++ b/spec/bot_spec.rb
@@ -7,6 +7,75 @@ RSpec.describe Viberroo::Bot do
   let(:response) { Viberroo::Response.new(event: 'message', sender: { id: '01234=' }) }
   let(:bot) { Viberroo::Bot.new(token: token, response: response) }
 
+  describe '#send_message' do
+    subject { bot.send_message(message: message, keyboard: keyboard) }
+
+    let(:message) do
+      {
+        text: 'hello',
+        event: 'message',
+        sender: { id: '1234=' },
+        receiver: response.user_id
+      }
+    end
+
+    context 'when keyboard does not contain inputs' do
+      let(:keyboard) { {} }
+
+      it 'does not contain :min_api_version attr in the params root' do
+        expect(bot).to receive(:request).with(
+          Viberroo::URL::MESSAGE,
+          { receiver: response.user_id }.merge(message)
+        )
+        subject
+      end
+    end
+
+    context 'when keyboard contain single input with api version' do
+      let(:button)          { Viberroo::Input.share_phone_button({}) }
+      let(:keyboard)        { Viberroo::Input.keyboard(Buttons: [button]) }
+      let(:min_api_version) { button[:min_api_version] }
+
+      it 'sets correct :min_api_version attr in the params root' do
+        expect(bot).to receive(:request).with(
+          Viberroo::URL::MESSAGE,
+          { receiver: response.user_id }.merge(message, keyboard, min_api_version: min_api_version)
+        )
+        subject
+      end
+    end
+
+    context 'when keyboard contain multiple inputs one of which has no api versions' do
+      let(:button_one)      { Viberroo::Input.share_phone_button({}) }
+      let(:button_two)      { Viberroo::Input.reply_button({}) }
+      let(:keyboard)        { Viberroo::Input.keyboard(Buttons: [button_one, button_two]) }
+      let(:min_api_version) { button_one[:min_api_version] }
+
+      it 'sets correct :min_api_version attr in the params root' do
+        expect(bot).to receive(:request).with(
+          Viberroo::URL::MESSAGE,
+          { receiver: response.user_id }.merge(message, keyboard, min_api_version: min_api_version)
+        )
+        subject
+      end
+    end
+
+    context 'when keyboard contain multiple inputs with different api versions' do
+      let(:button_one)      { Viberroo::Input.share_phone_button({ min_api_version: 3 }) }
+      let(:button_two)      { Viberroo::Input.reply_button({ min_api_version: 7 }) }
+      let(:keyboard)        { Viberroo::Input.keyboard(Buttons: [button_one, button_two]) }
+      let(:min_api_version) { button_two[:min_api_version] }
+
+      it 'sets correct :min_api_version attr in the params root' do
+        expect(bot).to receive(:request).with(
+          Viberroo::URL::MESSAGE,
+          { receiver: response.user_id }.merge(message, keyboard, min_api_version: min_api_version)
+        )
+        subject
+      end
+    end
+  end
+
   describe 'setting a webhook' do
     let(:bot) { Viberroo::Bot.new(token: token) }
     let!(:body) do

--- a/spec/bot_spec.rb
+++ b/spec/bot_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Viberroo::Bot do
   let(:bot) { Viberroo::Bot.new(token: token, response: response) }
 
   describe '#send_message' do
-    subject { bot.send_message(message: message, keyboard: keyboard) }
+    subject { bot.send_message(message, keyboard: keyboard) }
 
     let(:message) do
       {
@@ -35,6 +35,21 @@ RSpec.describe Viberroo::Bot do
       let(:button)          { Viberroo::Input.share_phone_button({}) }
       let(:keyboard)        { Viberroo::Input.keyboard(Buttons: [button]) }
       let(:min_api_version) { button[:min_api_version] }
+
+      it 'sets correct :min_api_version attr in the params root' do
+        expect(bot).to receive(:request).with(
+          Viberroo::URL::MESSAGE,
+          { receiver: response.user_id }.merge(message, keyboard, min_api_version: min_api_version)
+        )
+        subject
+      end
+    end
+
+    context 'when keyboard contain single input with api version but min_api-version was set before' do
+      let(:min_api_version) { 7 }
+      let(:message)         { { min_api_version: min_api_version } }
+      let(:button)          { Viberroo::Input.share_phone_button({}) }
+      let(:keyboard)        { Viberroo::Input.keyboard(Buttons: [button]) }
 
       it 'sets correct :min_api_version attr in the params root' do
         expect(bot).to receive(:request).with(

--- a/spec/bot_spec.rb
+++ b/spec/bot_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Viberroo::Bot do
     before { subject }
 
     context 'with #send_message' do
-      subject { bot.send_message(message) }
+      subject { bot.send_message(message: message) }
 
       it 'makes a request with correct url, body and headers' do
         expect(request).to have_been_made.once

--- a/spec/bot_spec.rb
+++ b/spec/bot_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Viberroo::Bot do
     before { subject }
 
     context 'with #send_message' do
-      subject { bot.send_message(message: message) }
+      subject { bot.send_message(message) }
 
       it 'makes a request with correct url, body and headers' do
         expect(request).to have_been_made.once


### PR DESCRIPTION
**Issue**
Using `Input`s that has required `min_api_version` should populate the result response with `min_api_version` in the ROOT of sending JSON to the Viber API but it's not.

**Changes**
- fix with missed `min_api_version` param
- fix of `send` and `send_message` methods with missed named argument